### PR TITLE
Fix typo for LateUpdate calls

### DIFF
--- a/IllusionInjector/PluginComponent.cs
+++ b/IllusionInjector/PluginComponent.cs
@@ -38,6 +38,11 @@ namespace IllusionInjector
             plugins.OnUpdate();
         }
 
+        void LateUpdate()
+        {
+            plugins.OnLateUpdate();
+        }
+
         void FixedUpdate()
         {
             plugins.OnFixedUpdate();
@@ -52,11 +57,6 @@ namespace IllusionInjector
         {
             plugins.OnLevelWasLoaded(level);
             freshlyLoaded = true;
-        }
-
-        void OnLateUpdate()
-        {
-            plugins.OnLateUpdate();
         }
 
     }


### PR DESCRIPTION
Plugins never called LateUpdate when using IEnhancedPlugin interface cuz there was a typo on the method's calling.
